### PR TITLE
[ci] Fix ssl and install docker in the base rust image

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -11,10 +11,18 @@ RUN rustup component add rustfmt clippy
 # 'libssl-dev' and 'pkg-config' are useful for compilation of Rust crate
 # 'openssl-sys' which is used by 'cargo-audit'. Once compiled and installed,
 # only the library 'libssl1.1' is needed.
-RUN apt update \
-	&& apt install --yes libssl1.1 libssl-dev pkg-config \
+# we also install docker to be able to release the project on a docker registry
+
+ARG DOCKER_VERSION="5:19.03.13~3-0~debian-buster"
+RUN BUILD_DEPENDENCIES="apt-transport-https curl gnupg-agent software-properties-common libssl-dev pkg-config" \
+	&& apt update \
+	&& apt install --yes libssl1.1 ca-certificates ${BUILD_DEPENDENCIES}\
 	&& cargo install cargo-audit \
-	&& apt purge --yes libssl-dev pkg-config \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add \
+    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
+    && apt update \
+    && apt -y install docker-ce-cli=${DOCKER_VERSION} \
+    && apt -y purge ${BUILD_DEPENDENCIES} \
 	&& apt autoremove --yes \
 	&& rm -rf /var/lib/apt/lists/*
 ENV CARGO_HOME=/tmp/cargo

--- a/rust/proj/Dockerfile
+++ b/rust/proj/Dockerfile
@@ -1,7 +1,6 @@
 ARG TAG=latest
 FROM kisiodigital/rust-ci:${TAG}
 
-ARG DOCKER_VERSION="5:19.03.13~3-0~debian-buster"
 ARG PROJ_VERSION="7.1.0"
 ENV PROJ_DEB "proj_${PROJ_VERSION}_amd64.deb"
 ENV GPG_KEY "C60D758F807A525534C5DFD57B639E3638A8112A"
@@ -10,19 +9,12 @@ ENV GPG_KEY "C60D758F807A525534C5DFD57B639E3638A8112A"
 # - 'proj' provides 'proj.h' and 'libproj.so', needed for compiling 'proj-sys'
 # - 'libtiff5' provides 'libtiff.so', needed for linking when 'proj-sys' is used
 # - 'libcurl3-nss' provides 'libcurl-nss.so', needed for linking when 'proj-sys' is used
-#
-# We also need to install docker
-RUN BUILD_DEPENDENCIES="apt-transport-https ca-certificates gnupg2 wget curl gnupg-agent software-properties-common" \
-	&& apt update \
-	&& apt install --yes ${BUILD_DEPENDENCIES} \
+RUN apt update \
+	&& apt install --yes apt-transport-https gnupg2 wget \
 	&& wget --quiet --output-document - "https://kisiodigital.jfrog.io/kisiodigital/api/gpg/key/public" | apt-key add - \
 	&& echo "deb [arch=amd64] https://kisiodigital.jfrog.io/kisiodigital/debian-local stretch main" > /etc/apt/sources.list.d/kisio-digital.list \
 	&& apt update \
 	&& apt install --yes clang proj=${PROJ_VERSION} libtiff5 libcurl3-nss \
-    && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add \
-    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
-    && apt update \
-    && apt -y install docker-ce-cli=${DOCKER_VERSION} \
-    && apt -y purge ${BUILD_DEPENDENCIES} \
+	&& apt purge --yes apt-transport-https gnupg2 wget \
 	&& apt autoremove --yes \
 	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I screwd up before, docker needs to be installed in the base image since it can be used by other projects.
I commited the wrong file ... :facepalm: 

This also brings back `ca-certificates` and this should fix tartare-tools ci problems