### PR TITLE
install git and certificates for precommit

### DIFF
--- a/tartare/Dockerfile
+++ b/tartare/Dockerfile
@@ -2,12 +2,15 @@ FROM python:3.6.5-slim-stretch
 
 ARG DOCKER_VERSION="5:19.03.13~3-0~debian-stretch"
 
-RUN BUILD_DEPENDENCIES="apt-transport-https ca-certificates curl gnupg-agent software-properties-common" \
+RUN BUILD_DEPENDENCIES="apt-transport-https curl gnupg-agent software-properties-common" \
     && apt-get update \
     && apt-get --yes install \
         # used in docker_wrapper.py for waiting until a container is up (wiremock)
         wget \
         make \
+        # used for precommit checks
+        git \
+        ca-certificates \
         ${BUILD_DEPENDENCIES} \
     && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add \
     && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \


### PR DESCRIPTION
used for https://github.com/CanalTP/tartare/pull/1077 for precommit

does not work yet though I got a weird pip / pyenv mixup