### PR TITLE
[feature] Bump to Rust 1.50.0

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.48-slim-buster
+FROM rust:1.50-slim-buster
 
 # Generic building tools
 RUN apt update \

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,29 +1,37 @@
 FROM rust:1.50-slim-buster
 
-# Generic building tools
+# Generic tools
 RUN apt update \
-	&& apt install --yes make \
-	&& apt autoremove --yes \
-	&& rm -rf /var/lib/apt/lists/*
+    && apt install --yes make git \
+    && apt autoremove --yes \
+    && rm -rf /var/lib/apt/lists/*
 
 # For Rust
 RUN rustup component add rustfmt clippy
 # 'libssl-dev' and 'pkg-config' are useful for compilation of Rust crate
 # 'openssl-sys' which is used by 'cargo-audit'. Once compiled and installed,
 # only the library 'libssl1.1' is needed.
-# we also install git and docker to be able to release the project on a docker registry
 
-ARG DOCKER_VERSION="5:19.03.13~3-0~debian-buster"
-RUN BUILD_DEPENDENCIES="apt-transport-https curl gnupg-agent software-properties-common libssl-dev pkg-config" \
-	&& apt update \
-	&& apt install --yes libssl1.1 git ca-certificates ${BUILD_DEPENDENCIES}\
-	&& cargo install cargo-audit \
+ARG AUDIT_BUILD_DEPENDENCIES="libssl-dev pkg-config"
+RUN apt update \
+    && apt install --yes libssl1.1 ca-certificates ${AUDIT_BUILD_DEPENDENCIES}\
+    && cargo install cargo-audit \
+    && apt -y purge ${AUDIT_BUILD_DEPENDENCIES} \
+    && apt autoremove --yes \
+    && rm -rf /var/lib/apt/lists/*git 
+
+# we also install docker to be able to release the project on a docker registry
+ARG DOCKER_BUILD_DEPENDENCIES="apt-transport-https curl gnupg-agent software-properties-common"
+ARG DOCKER_VERSION="5:20.10.3~3-0~debian-buster"
+RUN apt update \
+    && apt install --yes ${DOCKER_BUILD_DEPENDENCIES} \
     && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add \
     && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
     && apt update \
     && apt -y install docker-ce-cli=${DOCKER_VERSION} \
-    && apt -y purge ${BUILD_DEPENDENCIES} \
-	&& apt autoremove --yes \
-	&& rm -rf /var/lib/apt/lists/*
+    && apt -y purge ${DOCKER_BUILD_DEPENDENCIES} \
+    && apt autoremove --yes \
+    && rm -rf /var/lib/apt/lists/*git 
+
 ENV CARGO_HOME=/tmp/cargo
 ENV CARGO_TARGET_DIR=/tmp/cargo-target

--- a/rust/proj/Dockerfile
+++ b/rust/proj/Dockerfile
@@ -1,20 +1,24 @@
 ARG TAG=latest
 FROM kisiodigital/rust-ci:${TAG}
 
-ARG PROJ_VERSION="7.1.0"
-ENV PROJ_DEB "proj_${PROJ_VERSION}_amd64.deb"
-ENV GPG_KEY "C60D758F807A525534C5DFD57B639E3638A8112A"
+ARG PROJ_VERSION="7.2.1"
 # For building Rust's crate 'proj-sys', the following Debian packages are needed:
 # - 'clang' provides 'llvm-config', 'libclang.so' and 'stddef.h' needed for compiling 'proj-sys'
 # - 'proj' provides 'proj.h' and 'libproj.so', needed for compiling 'proj-sys'
 # - 'libtiff5' provides 'libtiff.so', needed for linking when 'proj-sys' is used
 # - 'libcurl3-nss' provides 'libcurl-nss.so', needed for linking when 'proj-sys' is used
+ARG BUILD_DEPENDENCIES="libcurl4-gnutls-dev libsqlite3-dev libtiff5-dev cmake pkg-config sqlite3 wget"
+ARG RUNTIME_DEPENDENCIES="clang libtiff5 libcurl3-nss"
 RUN apt update \
-	&& apt install --yes apt-transport-https gnupg2 wget \
-	&& wget --quiet --output-document - "https://kisiodigital.jfrog.io/kisiodigital/api/gpg/key/public" | apt-key add - \
-	&& echo "deb [arch=amd64] https://kisiodigital.jfrog.io/kisiodigital/debian-local stretch main" > /etc/apt/sources.list.d/kisio-digital.list \
-	&& apt update \
-	&& apt install --yes clang proj=${PROJ_VERSION} libtiff5 libcurl3-nss \
-	&& apt purge --yes apt-transport-https gnupg2 wget \
-	&& apt autoremove --yes \
-	&& rm -rf /var/lib/apt/lists/*
+    && apt install --yes ${BUILD_DEPENDENCIES} ${RUNTIME_DEPENDENCIES} \
+    && wget https://github.com/OSGeo/PROJ/releases/download/${PROJ_VERSION}/proj-${PROJ_VERSION}.tar.gz \
+    && tar -xzvf proj-${PROJ_VERSION}.tar.gz \
+    && mv proj-${PROJ_VERSION} /tmp/proj-src \
+    && cd /tmp/proj-src \
+    && ./configure --prefix=/usr \
+    && make -j$(nproc) \
+    && make install \
+    && rm -fr /proj-src \
+    && apt purge --yes ${BUILD_DEPENDENCIES} \
+    && apt autoremove --yes \
+    && rm -rf /var/lib/apt/lists/*

--- a/rust/proj/Dockerfile
+++ b/rust/proj/Dockerfile
@@ -2,13 +2,17 @@ ARG TAG=latest
 FROM kisiodigital/rust-ci:${TAG}
 
 ARG PROJ_VERSION="7.2.1"
-# For building Rust's crate 'proj-sys', the following Debian packages are needed:
+
+# For building `libproj' and the Rust's crate `proj-sys`, the following Debian packages are needed:
+ARG BUILD_DEPENDENCIES="libcurl4-gnutls-dev libsqlite3-dev libtiff5-dev cmake pkg-config sqlite3 wget"
+
+# For running `proj`, the following Debian packages are needed:
 # - 'clang' provides 'llvm-config', 'libclang.so' and 'stddef.h' needed for compiling 'proj-sys'
-# - 'proj' provides 'proj.h' and 'libproj.so', needed for compiling 'proj-sys'
 # - 'libtiff5' provides 'libtiff.so', needed for linking when 'proj-sys' is used
 # - 'libcurl3-nss' provides 'libcurl-nss.so', needed for linking when 'proj-sys' is used
-ARG BUILD_DEPENDENCIES="libcurl4-gnutls-dev libsqlite3-dev libtiff5-dev cmake pkg-config sqlite3 wget"
+# - 'proj' provides 'proj.h' and 'libproj.so', needed for compiling 'proj-sys' (installed manually below)
 ARG RUNTIME_DEPENDENCIES="clang libtiff5 libcurl3-nss"
+
 RUN apt update \
     && apt install --yes ${BUILD_DEPENDENCIES} ${RUNTIME_DEPENDENCIES} \
     && wget https://github.com/OSGeo/PROJ/releases/download/${PROJ_VERSION}/proj-${PROJ_VERSION}.tar.gz \


### PR DESCRIPTION
And a few other refactorizations:
- Better separation of steps in `rust-ci:latest` (0f1af22)
- Now compiles `proj` instead of using the custom `.deb` (f6035c0)