### PR TITLE
[fix] use 'nss' everywhere

### DIFF
--- a/rust/proj/Dockerfile
+++ b/rust/proj/Dockerfile
@@ -4,7 +4,7 @@ FROM kisiodigital/rust-ci:${TAG}
 ARG PROJ_VERSION="7.2.1"
 
 # For building `libproj' and the Rust's crate `proj-sys`, the following Debian packages are needed:
-ARG BUILD_DEPENDENCIES="libcurl4-gnutls-dev libsqlite3-dev libtiff5-dev cmake pkg-config sqlite3 wget"
+ARG BUILD_DEPENDENCIES="libcurl4-nss-dev libsqlite3-dev libtiff5-dev cmake pkg-config sqlite3 wget"
 
 # For running `proj`, the following Debian packages are needed:
 # - 'clang' provides 'llvm-config', 'libclang.so' and 'stddef.h' needed for compiling 'proj-sys'


### PR DESCRIPTION
I don't know how it was working before, but we were using `libcurl4-gnutls-dev` for the compilation of `proj`, then `libcurl3-nss` for the runtime (maybe `libcurl3-gnutls-dev` was installed by other dependencies?). We should either use `libcurl4-gnutls-dev`/`libcurl3-gnutls` together, or use `libcurl4-nss-dev`/`libcurl3-nss`. This PR uses the latter.

Here is a comparison of the implementations
https://curl.se/docs/ssl-compared.html