### PR TITLE
[feature] add 'proj-ci' image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,8 @@ pipeline {
                     steps {
                         script {
                             docker.withRegistry('', 'kisiodigital-user-dockerhub') {
+                                sh "make release_proj_artifacts"
+                                sh "make release_proj"
                                 sh "make release_rust"
                                 sh "make release_rust_proj"
                             }

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ release_proj_artifacts: ## Release docker image kisiodigital/proj-ci:7.2.1-stret
 
 .PHONY: release_proj
 release_proj: ## Release docker image kisiodigital/proj-ci:7.2.1-stretch
-	$(info > Build docker image kisiodigital/proj-ci:7.2.1-stretch-artifacts)
+	$(info > Build docker image kisiodigital/proj-ci:7.2.1-stretch)
 	@./release.sh $(if $(findstring true,${DRY_RUN}), --dry-run) --tag 7.2.1-stretch proj
 
 .PHONY: release_rust

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ release_rust: ## Release docker image kisiodigital/rust-ci:latest
 
 .PHONY: release_rust_proj
 release_rust_proj: ## Release docker image kisiodigital/rust-ci:latest-proj${PROJ_VERSION}
-	$(info > Build docker image kisiodigital/rust-ci:latest-proj)
+	$(info > Build docker image kisiodigital/rust-ci:latest-proj${PROJ_VERSION})
 	@./release.sh $(if $(findstring true,${DRY_RUN}), --dry-run) --tag latest-proj${PROJ_VERSION} rust proj
 
 .PHONY: release_tartare

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,16 @@ $(error DRY_RUN must be 'true' or 'false')
 endif
 endif
 
+.PHONY: release_proj_artifacts
+release_proj_artifacts: ## Release docker image kisiodigital/proj-ci:7.2.1-stretch-artifacts
+	$(info > Build docker image kisiodigital/proj-ci:7.2.1-stretch-artifacts)
+	@./release.sh $(if $(findstring true,${DRY_RUN}), --dry-run) --tag 7.2.1-stretch-artifacts --stage builder proj
+
+.PHONY: release_proj
+release_proj: ## Release docker image kisiodigital/proj-ci:7.2.1-stretch
+	$(info > Build docker image kisiodigital/proj-ci:7.2.1-stretch-artifacts)
+	@./release.sh $(if $(findstring true,${DRY_RUN}), --dry-run) --tag 7.2.1-stretch proj
+
 .PHONY: release_rust
 release_rust: ## Release docker image kisiodigital/rust-ci:latest
 	$(info > Build docker image kisiodigital/rust-ci:latest)

--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,17 @@ ifneq (${DRY_RUN},false)
 $(error DRY_RUN must be 'true' or 'false')
 endif
 endif
+PROJ_VERSION ?= 7.2.1
 
 .PHONY: release_proj_artifacts
-release_proj_artifacts: ## Release docker image kisiodigital/proj-ci:7.2.1-stretch-artifacts
-	$(info > Build docker image kisiodigital/proj-ci:7.2.1-stretch-artifacts)
-	@./release.sh $(if $(findstring true,${DRY_RUN}), --dry-run) --tag 7.2.1-stretch-artifacts --stage builder proj
+release_proj_artifacts: ## Release docker image kisiodigital/proj-ci:${PROJ_VERSION}-artifacts
+	$(info > Build docker image kisiodigital/proj-ci:${PROJ_VERSION}-artifacts)
+	@./release.sh $(if $(findstring true,${DRY_RUN}), --dry-run) --tag ${PROJ_VERSION}-artifacts --stage builder proj
 
 .PHONY: release_proj
-release_proj: ## Release docker image kisiodigital/proj-ci:7.2.1-stretch
-	$(info > Build docker image kisiodigital/proj-ci:7.2.1-stretch)
-	@./release.sh $(if $(findstring true,${DRY_RUN}), --dry-run) --tag 7.2.1-stretch proj
+release_proj: ## Release docker image kisiodigital/proj-ci:${PROJ_VERSION}
+	$(info > Build docker image kisiodigital/proj-ci:${PROJ_VERSION})
+	@./release.sh $(if $(findstring true,${DRY_RUN}), --dry-run) --tag ${PROJ_VERSION} proj
 
 .PHONY: release_rust
 release_rust: ## Release docker image kisiodigital/rust-ci:latest
@@ -22,9 +23,9 @@ release_rust: ## Release docker image kisiodigital/rust-ci:latest
 	@./release.sh $(if $(findstring true,${DRY_RUN}), --dry-run) rust
 
 .PHONY: release_rust_proj
-release_rust_proj: ## Release docker image kisiodigital/rust-ci:latest-proj
+release_rust_proj: ## Release docker image kisiodigital/rust-ci:latest-proj${PROJ_VERSION}
 	$(info > Build docker image kisiodigital/rust-ci:latest-proj)
-	@./release.sh $(if $(findstring true,${DRY_RUN}), --dry-run) rust proj
+	@./release.sh $(if $(findstring true,${DRY_RUN}), --dry-run) --tag latest-proj${PROJ_VERSION} rust proj
 
 .PHONY: release_tartare
 release_tartare: ## Release docker image kisiodigital/tartare-ci:latest

--- a/README.md
+++ b/README.md
@@ -7,6 +7,32 @@ This repository contains helpful Docker images for the CI with CanalTP's project
 A few Docker images are available containing most of the useful tools to build
 and verify projects.
 
+### `kisiodigital/proj-ci:7.2.1-stretch-artifacts`
+
+This Docker image provides pre-built artifacts for [proj] library,
+based on a Debian stretch.
+
+In order to use it in a multistage Docker image, you can do the following setup.
+
+```
+FROM kisiodigital/proj-ci:7.2.1-stretch-artifacts as proj-artifacts
+
+FROM debian:stretch
+
+COPY --from=proj-artifacts /proj-artifacts /
+ENV RUNTIME_DEPENDENCIES="clang libtiff5 libcurl3-nss"
+RUN apt update \
+    && apt install --yes ${RUNTIME_DEPENDENCIES} \
+    && apt autoremove --yes \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+Do not forget to install the runtime dependencies on which the [proj] artifacts depend.
+
+### `kisiodigital/proj-ci:7.2.1-stretch`
+
+This Docker image provides all the binaries and libraries of the project [proj].
+
 ### `kisiodigital/rust-ci:latest`
 
 Based on Docker image `rust`, it provides the additional tools:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ RUN apt update \
 
 Do not forget to install the runtime dependencies on which the [proj] artifacts depend.
 
-### `kisiodigital/proj-ci:7.2.1
+### `kisiodigital/proj-ci:7.2.1`
 
 This Docker image provides all the binaries and libraries of the project [proj],
 based on a Debian stretch.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains helpful Docker images for the CI with CanalTP's project
 A few Docker images are available containing most of the useful tools to build
 and verify projects.
 
-### `kisiodigital/proj-ci:7.2.1-stretch-artifacts`
+### `kisiodigital/proj-ci:7.2.1-artifacts`
 
 This Docker image provides pre-built artifacts for [proj] library,
 based on a Debian stretch.
@@ -15,7 +15,7 @@ based on a Debian stretch.
 In order to use it in a multistage Docker image, you can do the following setup.
 
 ```
-FROM kisiodigital/proj-ci:7.2.1-stretch-artifacts as proj-artifacts
+FROM kisiodigital/proj-ci:7.2.1-artifacts as proj-artifacts
 
 FROM debian:stretch
 
@@ -29,9 +29,10 @@ RUN apt update \
 
 Do not forget to install the runtime dependencies on which the [proj] artifacts depend.
 
-### `kisiodigital/proj-ci:7.2.1-stretch`
+### `kisiodigital/proj-ci:7.2.1
 
-This Docker image provides all the binaries and libraries of the project [proj].
+This Docker image provides all the binaries and libraries of the project [proj],
+based on a Debian stretch.
 
 ### `kisiodigital/rust-ci:latest`
 
@@ -43,13 +44,21 @@ Based on Docker image Debian stretch, it provides the additional tools:
 - [`cargo-audit`]: cargo tool to report known CVE in the dependencies
 - [`docker`]: docker engine
 
+If you want to release this image with the latest version of Rust, just trigger the Jenkins job manually.
+
+To know which version of Rust is embedded in the image, do the following:
+
+```sh
+docker run kisiodigital/rust-ci:latest rustc --version
+```
+
 [`rustup`]: https://rustup.rs/
 [`rustfmt`]: https://github.com/rust-lang/rustfmt
 [`clippy`]: https://github.com/rust-lang/rust-clippy
 [`cargo-audit`]: https://github.com/RustSec/cargo-audit
 [`docker`]: https://www.docker.com/
 
-#### Variant `kisiodigital/rust-ci:latest-proj`
+#### Variant `kisiodigital/rust-ci:latest-proj7.2.1`
 
 Based on Docker image `kisiodigital/rust-ci:latest`, it provides also the
 [Proj] library, allowing to compile a Rust project with [`proj`]'s crate.

--- a/README.md
+++ b/README.md
@@ -35,13 +35,19 @@ This Docker image provides all the binaries and libraries of the project [proj].
 
 ### `kisiodigital/rust-ci:latest`
 
-Based on Docker image `rust`, it provides the additional tools:
+Based on Docker image Debian stretch, it provides the additional tools:
 
+- [`rustup`]: setup for a functional Rust ecosystem
 - [`rustfmt`]: auto-formatting of the Rust source code
 - [`clippy`]: static linting of the Rust source code
+- [`cargo-audit`]: cargo tool to report known CVE in the dependencies
+- [`docker`]: docker engine
 
+[`rustup`]: https://rustup.rs/
 [`rustfmt`]: https://github.com/rust-lang/rustfmt
 [`clippy`]: https://github.com/rust-lang/rust-clippy
+[`cargo-audit`]: https://github.com/RustSec/cargo-audit
+[`docker`]: https://www.docker.com/
 
 #### Variant `kisiodigital/rust-ci:latest-proj`
 

--- a/proj/Dockerfile
+++ b/proj/Dockerfile
@@ -1,0 +1,34 @@
+FROM debian:stretch as builder
+
+ARG PROJ_VERSION="7.2.1"
+
+# For running `proj`, the following Debian packages are needed:
+# - 'clang' provides 'llvm-config', 'libclang.so' and 'stddef.h' needed for compiling 'proj-sys'
+# - 'libtiff5' provides 'libtiff.so', needed for linking when 'proj-sys' is used
+# - 'libcurl3-nss' provides 'libcurl-nss.so', needed for linking when 'proj-sys' is used
+# - 'proj' provides 'proj.h' and 'libproj.so', needed for compiling 'proj-sys' (installed manually below)
+ARG RUNTIME_DEPENDENCIES="clang libtiff5 libcurl3-nss"
+
+# For building `libproj' and the Rust's crate `proj-sys`, the following Debian packages are needed:
+ENV BUILD_DEPENDENCIES="libcurl4-nss-dev libsqlite3-dev libtiff5-dev cmake pkg-config sqlite3 wget"
+RUN apt update \
+    && apt install --yes ${BUILD_DEPENDENCIES} ${RUNTIME_DEPENDENCIES} \
+    && wget https://github.com/OSGeo/PROJ/releases/download/${PROJ_VERSION}/proj-${PROJ_VERSION}.tar.gz \
+    && tar -xzvf proj-${PROJ_VERSION}.tar.gz \
+    && mv proj-${PROJ_VERSION} /tmp/proj-src \
+    && cd /tmp/proj-src \
+    && ./configure --prefix=/usr \
+    && make -j$(nproc) \
+    && make DESTDIR=/proj-artifacts install \
+    && rm -fr /tmp/proj-src \
+    && apt purge --yes ${BUILD_DEPENDENCIES} \
+    && apt autoremove --yes \
+    && rm -rf /var/lib/apt/lists/*
+
+FROM debian:stretch
+ARG RUNTIME_DEPENDENCIES
+COPY --from=builder /proj-artifacts /
+RUN apt update \
+    && apt install --yes ${RUNTIME_DEPENDENCIES} \
+    && apt autoremove --yes \
+    && rm -rf /var/lib/apt/lists/*

--- a/release.sh
+++ b/release.sh
@@ -27,7 +27,7 @@ while [[ ${#} -gt 0 ]]; do
         STAGE="${1}" ;;
     '-d' | '--dry-run') DRY_RUN='true' ;;
     '-p' | '--proj-version') shift 1;
-    	PROJ_VERSION="${1}" ;;
+        PROJ_VERSION="${1}" ;;
     '-h' | '--help') echo "${HELP}" && exit 0 ;;
     *) if [[ "${1}" =~ ^- ]]; then
            Error "flag ${1} is unknown"

--- a/release.sh
+++ b/release.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 HELP="./release.sh <image> [<variant>]
+    -d | --dry-run    build but do not push docker images to the registry
+    -h | --help       display this help message
+    -t | --tag        specify the tag of the Docker image (default: 'latest' or 'latest-variant')
+    -s | --stage      specify an intermediate Docker stage to release (default: to latest stage)
 
 This script builds and pushes a Docker image named \`<image>-ci:latest\` using \`./<image>/Dockerfile\`.
 
@@ -16,10 +20,14 @@ DOCKER_NAMESPACE='kisiodigital'
 DRY_RUN='false'
 while [[ ${#} -gt 0 ]]; do
     case "${1}" in
+    '-t' | '--tag') shift 1;
+        TAG="${1}" ;;
+    '-s' | '--stage') shift 1 ;
+        STAGE="${1}" ;;
     '-d' | '--dry-run') DRY_RUN='true' ;;
-	'-h' | '--help') echo "${HELP}" && exit 0 ;;
+    '-h' | '--help') echo "${HELP}" && exit 0 ;;
     *) if [[ "${1}" =~ ^- ]]; then
-           Error "flag ${1} is unknown, the only recognized flag is '--dry-run (-d)'"
+           Error "flag ${1} is unknown"
        else
            if [[ -z "${IMAGE}" ]]; then
                IMAGE="${1}"
@@ -42,21 +50,22 @@ fi
 # [ -n "$(git status --untracked-files=no --porcelain)" ] && Error "git status is not clean, build aborted"
 
 # step 0: prepare docker image name with registry and tag
-# get the tag from git
-TAG=$(git describe --tags --abbrev=0 2> /dev/null)
-HAS_TAG=$(git tag --list --points-at HEAD)
-[ -z "${HAS_TAG}" ] && TAG='latest'
-[ -z "${TAG}" ] && Error "impossible to get a tag"
+# get the tag from git, only if not already specified (see '--tag' option)
+[ -z "${TAG}" ] && TAG=$(git describe --tags --abbrev=0 2> /dev/null)
+[ -z "${TAG}" ] && TAG=latest
 
 # step 1: build docker images for git HEAD
 if [[ -z "${IMAGE_VARIANT}" ]]; then
-	DOCKERFILE_PATH="./${IMAGE}/"
+    DOCKERFILE_PATH="./${IMAGE}/"
     IMAGE_FULLNAME="${DOCKER_NAMESPACE}/${IMAGE}-ci:${TAG}"
     BUILD_ARG=''
 else
-	DOCKERFILE_PATH="./${IMAGE}/${IMAGE_VARIANT}"
+    DOCKERFILE_PATH="./${IMAGE}/${IMAGE_VARIANT}"
     IMAGE_FULLNAME="${DOCKER_NAMESPACE}/${IMAGE}-ci:${TAG}-${IMAGE_VARIANT}"
     BUILD_ARG="--build-arg TAG=${TAG}"
+fi
+if [[ ! -z "${STAGE}" ]]; then
+    BUILD_ARG="${BUILD_ARG} --target ${STAGE}"
 fi
 echo "Building $IMAGE_FULLNAME"
 docker build --pull --no-cache --force-rm ${BUILD_ARG} --tag "${IMAGE_FULLNAME}" "${DOCKERFILE_PATH}"

--- a/release.sh
+++ b/release.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 HELP="./release.sh <image> [<variant>]
-    -d | --dry-run    build but do not push docker images to the registry
-    -h | --help       display this help message
-    -t | --tag        specify the tag of the Docker image (default: 'latest' or 'latest-variant')
-    -s | --stage      specify an intermediate Docker stage to release (default: to latest stage)
+    -d | --dry-run         build but do not push docker images to the registry
+    -p | --proj-version    version of proj dependency
+    -h | --help            display this help message
+    -t | --tag             specify the tag of the Docker image (default: 'latest' or 'latest-variant')
+    -s | --stage           specify an intermediate Docker stage to release (default: to latest stage)
 
 This script builds and pushes a Docker image named \`<image>-ci:latest\` using \`./<image>/Dockerfile\`.
 
@@ -25,6 +26,8 @@ while [[ ${#} -gt 0 ]]; do
     '-s' | '--stage') shift 1 ;
         STAGE="${1}" ;;
     '-d' | '--dry-run') DRY_RUN='true' ;;
+    '-p' | '--proj-version') shift 1;
+    	PROJ_VERSION="${1}" ;;
     '-h' | '--help') echo "${HELP}" && exit 0 ;;
     *) if [[ "${1}" =~ ^- ]]; then
            Error "flag ${1} is unknown"
@@ -66,6 +69,9 @@ else
 fi
 if [[ ! -z "${STAGE}" ]]; then
     BUILD_ARG="${BUILD_ARG} --target ${STAGE}"
+fi
+if [[ ! -z "${PROJ_VERSION}" ]]; then
+    BUILD_ARG="${BUILD_ARG} --build-arg ${PROJ_VERSION}"
 fi
 echo "Building $IMAGE_FULLNAME"
 docker build --pull --no-cache --force-rm ${BUILD_ARG} --tag "${IMAGE_FULLNAME}" "${DOCKERFILE_PATH}"

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,10 +1,19 @@
-FROM rust:1.50-slim-buster
+FROM debian:stretch
 
 # Generic tools
 RUN apt update \
-    && apt install --yes make git \
+    && apt install --yes build-essential git \
     && apt autoremove --yes \
     && rm -rf /var/lib/apt/lists/*
+
+# install rustup
+RUN apt update \
+    && apt install --yes curl \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+    && apt purge --yes curl \
+    && apt autoremove --yes \
+    && rm -rf /var/lib/apt/lists/*
+ENV PATH "/root/.cargo/bin:$PATH"
 
 # For Rust
 RUN rustup component add rustfmt clippy
@@ -22,13 +31,14 @@ RUN apt update \
 
 # we also install docker to be able to release the project on a docker registry
 ARG DOCKER_BUILD_DEPENDENCIES="apt-transport-https curl gnupg-agent software-properties-common"
-ARG DOCKER_VERSION="5:20.10.3~3-0~debian-buster"
+ARG DOCKER_VERSION="5:19.03.9~3-0~debian-stretch"
 RUN apt update \
     && apt install --yes ${DOCKER_BUILD_DEPENDENCIES} \
     && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add \
     && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
     && apt update \
     && apt -y install docker-ce-cli=${DOCKER_VERSION} \
+    && add-apt-repository --remove "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
     && apt -y purge ${DOCKER_BUILD_DEPENDENCIES} \
     && apt autoremove --yes \
     && rm -rf /var/lib/apt/lists/*git 

--- a/rust/proj/Dockerfile
+++ b/rust/proj/Dockerfile
@@ -1,5 +1,6 @@
 ARG TAG=latest
-FROM kisiodigital/proj-ci:7.2.1-stretch-artifacts as proj-artifacts
+ARG PROJ_VERSION=7.2.1
+FROM kisiodigital/proj-ci:${PROJ_VERSION}-artifacts as proj-artifacts
 FROM kisiodigital/rust-ci:${TAG}
 
 # For running `proj`, the following Debian packages are needed:

--- a/rust/proj/Dockerfile
+++ b/rust/proj/Dockerfile
@@ -1,10 +1,6 @@
 ARG TAG=latest
+FROM kisiodigital/proj-ci:7.2.1-stretch-artifacts as proj-artifacts
 FROM kisiodigital/rust-ci:${TAG}
-
-ARG PROJ_VERSION="7.2.1"
-
-# For building `libproj' and the Rust's crate `proj-sys`, the following Debian packages are needed:
-ARG BUILD_DEPENDENCIES="libcurl4-nss-dev libsqlite3-dev libtiff5-dev cmake pkg-config sqlite3 wget"
 
 # For running `proj`, the following Debian packages are needed:
 # - 'clang' provides 'llvm-config', 'libclang.so' and 'stddef.h' needed for compiling 'proj-sys'
@@ -12,17 +8,8 @@ ARG BUILD_DEPENDENCIES="libcurl4-nss-dev libsqlite3-dev libtiff5-dev cmake pkg-c
 # - 'libcurl3-nss' provides 'libcurl-nss.so', needed for linking when 'proj-sys' is used
 # - 'proj' provides 'proj.h' and 'libproj.so', needed for compiling 'proj-sys' (installed manually below)
 ARG RUNTIME_DEPENDENCIES="clang libtiff5 libcurl3-nss"
-
+COPY --from=proj-artifacts /proj-artifacts /
 RUN apt update \
-    && apt install --yes ${BUILD_DEPENDENCIES} ${RUNTIME_DEPENDENCIES} \
-    && wget https://github.com/OSGeo/PROJ/releases/download/${PROJ_VERSION}/proj-${PROJ_VERSION}.tar.gz \
-    && tar -xzvf proj-${PROJ_VERSION}.tar.gz \
-    && mv proj-${PROJ_VERSION} /tmp/proj-src \
-    && cd /tmp/proj-src \
-    && ./configure --prefix=/usr \
-    && make -j$(nproc) \
-    && make install \
-    && rm -fr /tmp/proj-src \
-    && apt purge --yes ${BUILD_DEPENDENCIES} \
+    && apt install --yes ${RUNTIME_DEPENDENCIES} \
     && apt autoremove --yes \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The goal of this PR is to factorize the installation of `proj` in our ecosystem of Docker images. For this, we keep the built artifacts in a folder of a Docker image's stage that anyone can use (see the documentation in the `README.md`).

The second commit make use of this new image for simplifying the image `kisiodigital/rust-ci:latest-proj` and make use of this `kisiodigital/proj-ci` image.

Another note: everything has been moved to Debian `stretch` for homogeneity. This means we're not using the official `rust` image which is now on `buster`.