### PR TITLE
[tech] Fix tag handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you want to release this image with the latest version of Rust, just trigger 
 To know which version of Rust is embedded in the image, do the following:
 
 ```sh
-docker run kisiodigital/rust-ci:latest rustc --version
+docker run -rm kisiodigital/rust-ci:latest rustc --version
 ```
 
 [`rustup`]: https://rustup.rs/

--- a/release.sh
+++ b/release.sh
@@ -22,7 +22,7 @@ DRY_RUN='false'
 while [[ ${#} -gt 0 ]]; do
     case "${1}" in
     '-t' | '--tag') shift 1;
-        TAG="${1}" ;;
+        IMAGE_TAG="${1}" ;;
     '-s' | '--stage') shift 1 ;
         STAGE="${1}" ;;
     '-d' | '--dry-run') DRY_RUN='true' ;;
@@ -54,18 +54,26 @@ fi
 
 # step 0: prepare docker image name with registry and tag
 # get the tag from git, only if not already specified (see '--tag' option)
-[ -z "${TAG}" ] && TAG=$(git describe --tags --abbrev=0 2> /dev/null)
-[ -z "${TAG}" ] && TAG=latest
+[ -z "${ARG_TAG}" ] && ARG_TAG=$(git describe --tags --abbrev=0 2> /dev/null)
+[ -z "${ARG_TAG}" ] && ARG_TAG=latest
 
 # step 1: build docker images for git HEAD
 if [[ -z "${IMAGE_VARIANT}" ]]; then
     DOCKERFILE_PATH="./${IMAGE}/"
-    IMAGE_FULLNAME="${DOCKER_NAMESPACE}/${IMAGE}-ci:${TAG}"
+    if [[ -z "${IMAGE_TAG}" ]]; then
+        IMAGE_FULLNAME="${DOCKER_NAMESPACE}/${IMAGE}-ci:${ARG_TAG}"
+    else
+        IMAGE_FULLNAME="${DOCKER_NAMESPACE}/${IMAGE}-ci:${IMAGE_TAG}"
+    fi
     BUILD_ARG=''
 else
     DOCKERFILE_PATH="./${IMAGE}/${IMAGE_VARIANT}"
-    IMAGE_FULLNAME="${DOCKER_NAMESPACE}/${IMAGE}-ci:${TAG}-${IMAGE_VARIANT}"
-    BUILD_ARG="--build-arg TAG=${TAG}"
+    if [[ -z "${IMAGE_TAG}" ]]; then
+        IMAGE_FULLNAME="${DOCKER_NAMESPACE}/${IMAGE}-ci:${ARG_TAG}-${IMAGE_VARIANT}"
+    else
+        IMAGE_FULLNAME="${DOCKER_NAMESPACE}/${IMAGE}-ci:${IMAGE_TAG}"
+    fi
+    BUILD_ARG="--build-arg TAG=${ARG_TAG}"
 fi
 if [[ ! -z "${STAGE}" ]]; then
     BUILD_ARG="${BUILD_ARG} --target ${STAGE}"


### PR DESCRIPTION
After https://jenkins-tool.canaltp.fr/blue/organizations/jenkins/ci-images/detail/master/14/pipeline/16
Build-arg TAG must be decorrelated from the image TAG.