### PR TITLE
[feature] add 'proj-ci' image (for good)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,8 @@ pipeline {
                     steps {
                         script {
                             docker.withRegistry('', 'kisiodigital-user-dockerhub') {
+                                sh "make release_proj_artifacts"
+                                sh "make release_proj"
                                 sh "make release_rust"
                                 sh "make release_rust_proj"
                             }

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,17 @@ ifneq (${DRY_RUN},false)
 $(error DRY_RUN must be 'true' or 'false')
 endif
 endif
+PROJ_VERSION ?= 7.2.1
+
+.PHONY: release_proj_artifacts
+release_proj_artifacts: ## Release docker image kisiodigital/proj-ci:${PROJ_VERSION}-artifacts
+	$(info > Build docker image kisiodigital/proj-ci:${PROJ_VERSION}-artifacts)
+	@./release.sh $(if $(findstring true,${DRY_RUN}), --dry-run) --tag ${PROJ_VERSION}-artifacts --stage builder proj
+
+.PHONY: release_proj
+release_proj: ## Release docker image kisiodigital/proj-ci:${PROJ_VERSION}
+	$(info > Build docker image kisiodigital/proj-ci:${PROJ_VERSION})
+	@./release.sh $(if $(findstring true,${DRY_RUN}), --dry-run) --tag ${PROJ_VERSION} proj
 
 .PHONY: release_rust
 release_rust: ## Release docker image kisiodigital/rust-ci:latest
@@ -12,9 +23,9 @@ release_rust: ## Release docker image kisiodigital/rust-ci:latest
 	@./release.sh $(if $(findstring true,${DRY_RUN}), --dry-run) rust
 
 .PHONY: release_rust_proj
-release_rust_proj: ## Release docker image kisiodigital/rust-ci:latest-proj
-	$(info > Build docker image kisiodigital/rust-ci:latest-proj)
-	@./release.sh $(if $(findstring true,${DRY_RUN}), --dry-run) rust proj
+release_rust_proj: ## Release docker image kisiodigital/rust-ci:latest-proj${PROJ_VERSION}
+	$(info > Build docker image kisiodigital/rust-ci:latest-proj${PROJ_VERSION})
+	@./release.sh $(if $(findstring true,${DRY_RUN}), --dry-run) --tag latest-proj${PROJ_VERSION} rust proj
 
 .PHONY: release_tartare
 release_tartare: ## Release docker image kisiodigital/tartare-ci:latest

--- a/README.md
+++ b/README.md
@@ -7,17 +7,58 @@ This repository contains helpful Docker images for the CI with CanalTP's project
 A few Docker images are available containing most of the useful tools to build
 and verify projects.
 
+### `kisiodigital/proj-ci:7.2.1-artifacts`
+
+This Docker image provides pre-built artifacts for [proj] library,
+based on a Debian stretch.
+
+In order to use it in a multistage Docker image, you can do the following setup.
+
+```
+FROM kisiodigital/proj-ci:7.2.1-artifacts as proj-artifacts
+
+FROM debian:stretch
+
+COPY --from=proj-artifacts /proj-artifacts /
+ENV RUNTIME_DEPENDENCIES="clang libtiff5 libcurl3-nss"
+RUN apt update \
+    && apt install --yes ${RUNTIME_DEPENDENCIES} \
+    && apt autoremove --yes \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+Do not forget to install the runtime dependencies on which the [proj] artifacts depend.
+
+### `kisiodigital/proj-ci:7.2.1`
+
+This Docker image provides all the binaries and libraries of the project [proj],
+based on a Debian stretch.
+
 ### `kisiodigital/rust-ci:latest`
 
-Based on Docker image `rust`, it provides the additional tools:
+Based on Docker image Debian stretch, it provides the additional tools:
 
+- [`rustup`]: setup for a functional Rust ecosystem
 - [`rustfmt`]: auto-formatting of the Rust source code
 - [`clippy`]: static linting of the Rust source code
+- [`cargo-audit`]: cargo tool to report known CVE in the dependencies
+- [`docker`]: docker engine
 
+If you want to release this image with the latest version of Rust, just trigger the Jenkins job manually.
+
+To know which version of Rust is embedded in the image, do the following:
+
+```sh
+docker run -rm kisiodigital/rust-ci:latest rustc --version
+```
+
+[`rustup`]: https://rustup.rs/
 [`rustfmt`]: https://github.com/rust-lang/rustfmt
 [`clippy`]: https://github.com/rust-lang/rust-clippy
+[`cargo-audit`]: https://github.com/RustSec/cargo-audit
+[`docker`]: https://www.docker.com/
 
-#### Variant `kisiodigital/rust-ci:latest-proj`
+#### Variant `kisiodigital/rust-ci:latest-proj7.2.1`
 
 Based on Docker image `kisiodigital/rust-ci:latest`, it provides also the
 [Proj] library, allowing to compile a Rust project with [`proj`]'s crate.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Based on Docker image Debian stretch, it provides the additional tools:
 - [`docker`]: docker engine
 
 If you want to release this image with the latest version of Rust, just trigger the Jenkins job manually.
+It is also possible to pin a specific Rust version by providing `--default-toolchain` param to
+rustup-init script.
 
 To know which version of Rust is embedded in the image, do the following:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ FROM kisiodigital/proj-ci:7.2.1-artifacts as proj-artifacts
 FROM debian:stretch
 
 COPY --from=proj-artifacts /proj-artifacts /
-ENV RUNTIME_DEPENDENCIES="clang libtiff5 libcurl3-nss"
+ENV RUNTIME_DEPENDENCIES="clang libtiff5 libcurl3-nss libsqlite3-0"
 RUN apt update \
     && apt install --yes ${RUNTIME_DEPENDENCIES} \
     && apt autoremove --yes \
@@ -28,6 +28,13 @@ RUN apt update \
 ```
 
 Do not forget to install the runtime dependencies on which the [proj] artifacts depend.
+
+> For running `proj`, the following Debian packages are needed:
+> - 'clang' provides 'llvm-config', 'libclang.so' and 'stddef.h' needed for compiling 'proj-sys'
+> - 'libtiff5' provides 'libtiff.so', needed for linking when 'proj-sys' is used
+> - 'libcurl3-nss' provides 'libcurl-nss.so', needed for linking when 'proj-sys' is used
+> - 'libsqlite3-0' is used by proj to manage different projections definitions (EPSG)
+> - 'proj' provides 'proj.h' and 'libproj.so', needed for compiling 'proj-sys' (installed manually below)
 
 ### `kisiodigital/proj-ci:7.2.1`
 

--- a/proj/Dockerfile
+++ b/proj/Dockerfile
@@ -1,13 +1,8 @@
+ARG RUNTIME_DEPENDENCIES="clang libtiff5 libcurl3-nss libsqlite3-0"
+
 FROM debian:stretch as builder
-
+ARG RUNTIME_DEPENDENCIES
 ARG PROJ_VERSION="7.2.1"
-
-# For running `proj`, the following Debian packages are needed:
-# - 'clang' provides 'llvm-config', 'libclang.so' and 'stddef.h' needed for compiling 'proj-sys'
-# - 'libtiff5' provides 'libtiff.so', needed for linking when 'proj-sys' is used
-# - 'libcurl3-nss' provides 'libcurl-nss.so', needed for linking when 'proj-sys' is used
-# - 'proj' provides 'proj.h' and 'libproj.so', needed for compiling 'proj-sys' (installed manually below)
-ARG RUNTIME_DEPENDENCIES="clang libtiff5 libcurl3-nss"
 
 # For building `libproj' and the Rust's crate `proj-sys`, the following Debian packages are needed:
 ENV BUILD_DEPENDENCIES="libcurl4-nss-dev libsqlite3-dev libtiff5-dev cmake pkg-config sqlite3 wget"

--- a/proj/Dockerfile
+++ b/proj/Dockerfile
@@ -1,0 +1,34 @@
+FROM debian:stretch as builder
+
+ARG PROJ_VERSION="7.2.1"
+
+# For running `proj`, the following Debian packages are needed:
+# - 'clang' provides 'llvm-config', 'libclang.so' and 'stddef.h' needed for compiling 'proj-sys'
+# - 'libtiff5' provides 'libtiff.so', needed for linking when 'proj-sys' is used
+# - 'libcurl3-nss' provides 'libcurl-nss.so', needed for linking when 'proj-sys' is used
+# - 'proj' provides 'proj.h' and 'libproj.so', needed for compiling 'proj-sys' (installed manually below)
+ARG RUNTIME_DEPENDENCIES="clang libtiff5 libcurl3-nss"
+
+# For building `libproj' and the Rust's crate `proj-sys`, the following Debian packages are needed:
+ENV BUILD_DEPENDENCIES="libcurl4-nss-dev libsqlite3-dev libtiff5-dev cmake pkg-config sqlite3 wget"
+RUN apt update \
+    && apt install --yes ${BUILD_DEPENDENCIES} ${RUNTIME_DEPENDENCIES} \
+    && wget https://github.com/OSGeo/PROJ/releases/download/${PROJ_VERSION}/proj-${PROJ_VERSION}.tar.gz \
+    && tar -xzvf proj-${PROJ_VERSION}.tar.gz \
+    && mv proj-${PROJ_VERSION} /tmp/proj-src \
+    && cd /tmp/proj-src \
+    && ./configure --prefix=/usr \
+    && make -j$(nproc) \
+    && make DESTDIR=/proj-artifacts install \
+    && rm -fr /tmp/proj-src \
+    && apt purge --yes ${BUILD_DEPENDENCIES} \
+    && apt autoremove --yes \
+    && rm -rf /var/lib/apt/lists/*
+
+FROM debian:stretch
+ARG RUNTIME_DEPENDENCIES
+COPY --from=builder /proj-artifacts /
+RUN apt update \
+    && apt install --yes ${RUNTIME_DEPENDENCIES} \
+    && apt autoremove --yes \
+    && rm -rf /var/lib/apt/lists/*

--- a/release.sh
+++ b/release.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 HELP="./release.sh <image> [<variant>]
+    -d | --dry-run         build but do not push docker images to the registry
+    -p | --proj-version    version of proj dependency
+    -h | --help            display this help message
+    -t | --tag             specify the tag of the Docker image (default: 'latest' or 'latest-variant')
+    -s | --stage           specify an intermediate Docker stage to release (default: to latest stage)
 
 This script builds and pushes a Docker image named \`<image>-ci:latest\` using \`./<image>/Dockerfile\`.
 
@@ -16,10 +21,16 @@ DOCKER_NAMESPACE='kisiodigital'
 DRY_RUN='false'
 while [[ ${#} -gt 0 ]]; do
     case "${1}" in
+    '-t' | '--tag') shift 1;
+        IMAGE_TAG="${1}" ;;
+    '-s' | '--stage') shift 1 ;
+        STAGE="${1}" ;;
     '-d' | '--dry-run') DRY_RUN='true' ;;
-	'-h' | '--help') echo "${HELP}" && exit 0 ;;
+    '-p' | '--proj-version') shift 1;
+        PROJ_VERSION="${1}" ;;
+    '-h' | '--help') echo "${HELP}" && exit 0 ;;
     *) if [[ "${1}" =~ ^- ]]; then
-           Error "flag ${1} is unknown, the only recognized flag is '--dry-run (-d)'"
+           Error "flag ${1} is unknown"
        else
            if [[ -z "${IMAGE}" ]]; then
                IMAGE="${1}"
@@ -42,21 +53,33 @@ fi
 # [ -n "$(git status --untracked-files=no --porcelain)" ] && Error "git status is not clean, build aborted"
 
 # step 0: prepare docker image name with registry and tag
-# get the tag from git
-TAG=$(git describe --tags --abbrev=0 2> /dev/null)
-HAS_TAG=$(git tag --list --points-at HEAD)
-[ -z "${HAS_TAG}" ] && TAG='latest'
-[ -z "${TAG}" ] && Error "impossible to get a tag"
+# get the tag from git, only if not already specified (see '--tag' option)
+[ -z "${ARG_TAG}" ] && ARG_TAG=$(git describe --tags --abbrev=0 2> /dev/null)
+[ -z "${ARG_TAG}" ] && ARG_TAG=latest
 
 # step 1: build docker images for git HEAD
 if [[ -z "${IMAGE_VARIANT}" ]]; then
-	DOCKERFILE_PATH="./${IMAGE}/"
-    IMAGE_FULLNAME="${DOCKER_NAMESPACE}/${IMAGE}-ci:${TAG}"
+    DOCKERFILE_PATH="./${IMAGE}/"
+    if [[ -z "${IMAGE_TAG}" ]]; then
+        IMAGE_FULLNAME="${DOCKER_NAMESPACE}/${IMAGE}-ci:${ARG_TAG}"
+    else
+        IMAGE_FULLNAME="${DOCKER_NAMESPACE}/${IMAGE}-ci:${IMAGE_TAG}"
+    fi
     BUILD_ARG=''
 else
-	DOCKERFILE_PATH="./${IMAGE}/${IMAGE_VARIANT}"
-    IMAGE_FULLNAME="${DOCKER_NAMESPACE}/${IMAGE}-ci:${TAG}-${IMAGE_VARIANT}"
-    BUILD_ARG="--build-arg TAG=${TAG}"
+    DOCKERFILE_PATH="./${IMAGE}/${IMAGE_VARIANT}"
+    if [[ -z "${IMAGE_TAG}" ]]; then
+        IMAGE_FULLNAME="${DOCKER_NAMESPACE}/${IMAGE}-ci:${ARG_TAG}-${IMAGE_VARIANT}"
+    else
+        IMAGE_FULLNAME="${DOCKER_NAMESPACE}/${IMAGE}-ci:${IMAGE_TAG}"
+    fi
+    BUILD_ARG="--build-arg TAG=${ARG_TAG}"
+fi
+if [[ ! -z "${STAGE}" ]]; then
+    BUILD_ARG="${BUILD_ARG} --target ${STAGE}"
+fi
+if [[ ! -z "${PROJ_VERSION}" ]]; then
+    BUILD_ARG="${BUILD_ARG} --build-arg ${PROJ_VERSION}"
 fi
 echo "Building $IMAGE_FULLNAME"
 docker build --pull --no-cache --force-rm ${BUILD_ARG} --tag "${IMAGE_FULLNAME}" "${DOCKERFILE_PATH}"

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,33 +1,43 @@
-FROM debian:stretch
+FROM debian:stretch-backports
 
 # Generic tools
 RUN apt update \
-    && apt install --yes build-essential git \
+    && apt install --yes build-essential git-man/stretch-backports git/stretch-backports \
+    && git --version \
     && apt autoremove --yes \
     && rm -rf /var/lib/apt/lists/*
 
-# install rustup
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo
+
+# install rustup for all users (inspired by rust official image Dockerfile)
+ENV PATH=/usr/local/cargo/bin:${PATH}
 RUN apt update \
     && apt install --yes curl \
-    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal \
+    && chmod -R a+w ${RUSTUP_HOME} ${CARGO_HOME} \
+    && rustup --version \
+    && cargo --version \
+    && rustc --version \
     && apt purge --yes curl \
     && apt autoremove --yes \
     && rm -rf /var/lib/apt/lists/*
-ENV PATH "/root/.cargo/bin:$PATH"
 
-# For Rust
-RUN rustup component add rustfmt clippy
+# Rust tools
+RUN rustup component add rustfmt clippy \
+    && chmod -R a+w ${RUSTUP_HOME} ${CARGO_HOME}
+
 # 'libssl-dev' and 'pkg-config' are useful for compilation of Rust crate
 # 'openssl-sys' which is used by 'cargo-audit'. Once compiled and installed,
 # only the library 'libssl1.1' is needed.
-
 ARG AUDIT_BUILD_DEPENDENCIES="libssl-dev pkg-config"
 RUN apt update \
     && apt install --yes libssl1.1 ca-certificates ${AUDIT_BUILD_DEPENDENCIES}\
     && cargo install cargo-audit \
+    && chmod -R a+w ${RUSTUP_HOME} ${CARGO_HOME} \
     && apt -y purge ${AUDIT_BUILD_DEPENDENCIES} \
     && apt autoremove --yes \
-    && rm -rf /var/lib/apt/lists/*git 
+    && rm -rf /var/lib/apt/lists/*
 
 # we also install docker to be able to release the project on a docker registry
 ARG DOCKER_BUILD_DEPENDENCIES="apt-transport-https curl gnupg-agent software-properties-common"
@@ -41,7 +51,7 @@ RUN apt update \
     && add-apt-repository --remove "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
     && apt -y purge ${DOCKER_BUILD_DEPENDENCIES} \
     && apt autoremove --yes \
-    && rm -rf /var/lib/apt/lists/*git 
+    && rm -rf /var/lib/apt/lists/*
 
 ENV CARGO_HOME=/tmp/cargo
 ENV CARGO_TARGET_DIR=/tmp/cargo-target

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -15,7 +15,7 @@ ENV PATH=/usr/local/cargo/bin:${PATH}
 RUN apt update \
     && apt install --yes curl \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal \
-    && chmod -R a+w ${RUSTUP_HOME} ${CARGO_HOME} \
+    && chmod -R a+wrX ${RUSTUP_HOME} ${CARGO_HOME} \
     && rustup --version \
     && cargo --version \
     && rustc --version \
@@ -25,7 +25,7 @@ RUN apt update \
 
 # Rust tools
 RUN rustup component add rustfmt clippy \
-    && chmod -R a+w ${RUSTUP_HOME} ${CARGO_HOME}
+    && chmod -R a+wrX ${RUSTUP_HOME} ${CARGO_HOME}
 
 # 'libssl-dev' and 'pkg-config' are useful for compilation of Rust crate
 # 'openssl-sys' which is used by 'cargo-audit'. Once compiled and installed,
@@ -34,7 +34,7 @@ ARG AUDIT_BUILD_DEPENDENCIES="libssl-dev pkg-config"
 RUN apt update \
     && apt install --yes libssl1.1 ca-certificates ${AUDIT_BUILD_DEPENDENCIES}\
     && cargo install cargo-audit \
-    && chmod -R a+w ${RUSTUP_HOME} ${CARGO_HOME} \
+    && chmod -R a+wrX ${RUSTUP_HOME} ${CARGO_HOME} \
     && apt -y purge ${AUDIT_BUILD_DEPENDENCIES} \
     && apt autoremove --yes \
     && rm -rf /var/lib/apt/lists/*
@@ -53,5 +53,5 @@ RUN apt update \
     && apt autoremove --yes \
     && rm -rf /var/lib/apt/lists/*
 
-ENV CARGO_HOME=/tmp/cargo
+# define target_dir to avoid leaking builds with different permissions on host (when mounting sources)
 ENV CARGO_TARGET_DIR=/tmp/cargo-target

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,10 +1,19 @@
-FROM rust:1.51-slim-buster
+FROM debian:stretch
 
 # Generic tools
 RUN apt update \
-    && apt install --yes make git \
+    && apt install --yes build-essential git \
     && apt autoremove --yes \
     && rm -rf /var/lib/apt/lists/*
+
+# install rustup
+RUN apt update \
+    && apt install --yes curl \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+    && apt purge --yes curl \
+    && apt autoremove --yes \
+    && rm -rf /var/lib/apt/lists/*
+ENV PATH "/root/.cargo/bin:$PATH"
 
 # For Rust
 RUN rustup component add rustfmt clippy
@@ -22,13 +31,14 @@ RUN apt update \
 
 # we also install docker to be able to release the project on a docker registry
 ARG DOCKER_BUILD_DEPENDENCIES="apt-transport-https curl gnupg-agent software-properties-common"
-ARG DOCKER_VERSION="5:20.10.3~3-0~debian-buster"
+ARG DOCKER_VERSION="5:19.03.9~3-0~debian-stretch"
 RUN apt update \
     && apt install --yes ${DOCKER_BUILD_DEPENDENCIES} \
     && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add \
     && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
     && apt update \
     && apt -y install docker-ce-cli=${DOCKER_VERSION} \
+    && add-apt-repository --remove "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
     && apt -y purge ${DOCKER_BUILD_DEPENDENCIES} \
     && apt autoremove --yes \
     && rm -rf /var/lib/apt/lists/*git 

--- a/rust/proj/Dockerfile
+++ b/rust/proj/Dockerfile
@@ -3,12 +3,7 @@ ARG PROJ_VERSION=7.2.1
 FROM kisiodigital/proj-ci:${PROJ_VERSION}-artifacts as proj-artifacts
 FROM kisiodigital/rust-ci:${TAG}
 
-# For running `proj`, the following Debian packages are needed:
-# - 'clang' provides 'llvm-config', 'libclang.so' and 'stddef.h' needed for compiling 'proj-sys'
-# - 'libtiff5' provides 'libtiff.so', needed for linking when 'proj-sys' is used
-# - 'libcurl3-nss' provides 'libcurl-nss.so', needed for linking when 'proj-sys' is used
-# - 'proj' provides 'proj.h' and 'libproj.so', needed for compiling 'proj-sys' (installed manually below)
-ARG RUNTIME_DEPENDENCIES="clang libtiff5 libcurl3-nss"
+ARG RUNTIME_DEPENDENCIES="clang libtiff5 libcurl3-nss libsqlite3-0"
 COPY --from=proj-artifacts /proj-artifacts /
 RUN apt update \
     && apt install --yes ${RUNTIME_DEPENDENCIES} \

--- a/rust/proj/Dockerfile
+++ b/rust/proj/Dockerfile
@@ -1,10 +1,7 @@
 ARG TAG=latest
+ARG PROJ_VERSION=7.2.1
+FROM kisiodigital/proj-ci:${PROJ_VERSION}-artifacts as proj-artifacts
 FROM kisiodigital/rust-ci:${TAG}
-
-ARG PROJ_VERSION="7.2.1"
-
-# For building `libproj' and the Rust's crate `proj-sys`, the following Debian packages are needed:
-ARG BUILD_DEPENDENCIES="libcurl4-nss-dev libsqlite3-dev libtiff5-dev cmake pkg-config sqlite3 wget"
 
 # For running `proj`, the following Debian packages are needed:
 # - 'clang' provides 'llvm-config', 'libclang.so' and 'stddef.h' needed for compiling 'proj-sys'
@@ -12,17 +9,8 @@ ARG BUILD_DEPENDENCIES="libcurl4-nss-dev libsqlite3-dev libtiff5-dev cmake pkg-c
 # - 'libcurl3-nss' provides 'libcurl-nss.so', needed for linking when 'proj-sys' is used
 # - 'proj' provides 'proj.h' and 'libproj.so', needed for compiling 'proj-sys' (installed manually below)
 ARG RUNTIME_DEPENDENCIES="clang libtiff5 libcurl3-nss"
-
+COPY --from=proj-artifacts /proj-artifacts /
 RUN apt update \
-    && apt install --yes ${BUILD_DEPENDENCIES} ${RUNTIME_DEPENDENCIES} \
-    && wget https://github.com/OSGeo/PROJ/releases/download/${PROJ_VERSION}/proj-${PROJ_VERSION}.tar.gz \
-    && tar -xzvf proj-${PROJ_VERSION}.tar.gz \
-    && mv proj-${PROJ_VERSION} /tmp/proj-src \
-    && cd /tmp/proj-src \
-    && ./configure --prefix=/usr \
-    && make -j$(nproc) \
-    && make install \
-    && rm -fr /tmp/proj-src \
-    && apt purge --yes ${BUILD_DEPENDENCIES} \
+    && apt install --yes ${RUNTIME_DEPENDENCIES} \
     && apt autoremove --yes \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Revert #22 (so #20 and #21 are back), with an extra-commit.
Extra-commit to have cargo available for all users (this is needed on CI agents) and a "recent" git version (needed by submodule management in github actions).

TODO:

- [x] tested after pushing `kisiodigital/rust-ci:latest-proj7.2.1` from my computer, and using it on https://github.com/CanalTP/transit_model/pull/757 (+ other closed project)
- [x] Try to build images from dockerfiles in TM and other depending projects
- [x] Merge just after next TM release to avoid blocking all work at a bad time if bugs are left