### PR TITLE
update clang and add pkg_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@ and verify projects.
 This Docker image provides pre-built artifacts for [proj] library,
 based on a Debian stretch.
 
-In order to use it in a multistage Docker image, you can do the following setup.
+In order to use it in a multistage Docker image, you can do the following setup (make sure that clang is >=3.9).
 
-```
+```sh
 FROM kisiodigital/proj-ci:7.2.1-artifacts as proj-artifacts
 
 FROM debian:stretch
 
 COPY --from=proj-artifacts /proj-artifacts /
-ARG RUNTIME_DEPENDENCIES="clang libclang1-3.9 pkg-config libtiff5 libcurl3-nss libsqlite3-0"
+ARG RUNTIME_DEPENDENCIES="pkg-config libtiff5 libcurl3-nss libsqlite3-0 clang" # or clang-3.9
 RUN apt update \
     && apt install --yes ${RUNTIME_DEPENDENCIES} \
     && apt autoremove --yes \
@@ -30,7 +30,7 @@ RUN apt update \
 Do not forget to install the runtime dependencies on which the [proj] artifacts depend.
 
 > For running `proj`, the following Debian packages are needed:
-> - 'clang' provides 'llvm-config', 'libclang.so' and 'stddef.h' needed for compiling 'proj-sys' (version 3.9 needed by proj-sys)
+> - 'clang' provides 'llvm-config', 'libclang.so' and 'stddef.h' needed for compiling 'proj-sys' (clang >=3.9 needed by proj-sys)
 > - 'pkg-config' needed by 'proj-sys' to find the installed version
 > - 'libtiff5' provides 'libtiff.so', needed for linking when 'proj-sys' is used
 > - 'libcurl3-nss' provides 'libcurl-nss.so', needed for linking when 'proj-sys' is used

--- a/README.md
+++ b/README.md
@@ -12,7 +12,22 @@ and verify projects.
 This Docker image provides pre-built artifacts for [proj] library,
 based on a Debian stretch.
 
-In order to use it in a multistage Docker image, you can do the following setup (make sure that clang is >=3.9).
+Do not forget to install the runtime dependencies on which the [proj] artifacts depend.
+
+> For developing or running `proj`, the following Debian packages are needed:
+>
+> - 'pkg-config' needed for compiling 'proj-sys' rust crate to find the installed version
+> - 'clang-7' provides 'llvm-config', 'libclang.so' and 'stddef.h' needed for compiling/using 'proj-sys' (clang >=3.9 needed by crate proj-sys)
+> - 'libtiff5' provides 'libtiff.so', needed for linking when 'proj-sys' is used
+> - 'libcurl3-nss' provides 'libcurl-nss.so', needed for linking when 'proj-sys' is used
+> - 'libsqlite3-0' is used by proj to manage different projections definitions (EPSG)
+> - 'proj' provides 'proj.h' and 'libproj.so', needed for compiling 'proj-sys' (installed manually below)
+
+In order to use it in a multistage Docker image, you may use one of the following setups.
+
+#### Rust development
+
+`proj` crate requires pkg-config and clang >=3.9.
 
 ```dockerfile
 FROM kisiodigital/proj-ci:7.2.1-artifacts as proj-artifacts
@@ -20,23 +35,27 @@ FROM kisiodigital/proj-ci:7.2.1-artifacts as proj-artifacts
 FROM debian:stretch
 
 COPY --from=proj-artifacts /proj-artifacts /
-ARG RUNTIME_DEPENDENCIES="clang-7 pkg-config libtiff5 libcurl3-nss libsqlite3-0"
+ARG PROJ_RUST_DEV_DEPENDENCIES="clang-7 pkg-config libtiff5 libcurl3-nss libsqlite3-0"
 RUN apt update \
-    && apt install --yes ${RUNTIME_DEPENDENCIES} \
+    && apt install --yes ${PROJ_RUST_DEV_DEPENDENCIES} \
     && apt autoremove --yes \
     && rm -rf /var/lib/apt/lists/*
 ```
 
-Do not forget to install the runtime dependencies on which the [proj] artifacts depend.
+#### Runtime
 
-> For developing with or running `proj`, the following Debian packages are needed:
->
-> - 'pkg-config' needed for compiling 'proj-sys' rust crate to find the installed version
-> - 'clang-7' provides 'llvm-config', 'libclang.so' and 'stddef.h' needed for compiling 'proj-sys' (clang >=3.9 needed by proj-sys)
-> - 'libtiff5' provides 'libtiff.so', needed for linking when 'proj-sys' is used
-> - 'libcurl3-nss' provides 'libcurl-nss.so', needed for linking when 'proj-sys' is used
-> - 'libsqlite3-0' is used by proj to manage different projections definitions (EPSG)
-> - 'proj' provides 'proj.h' and 'libproj.so', needed for compiling 'proj-sys' (installed manually below)
+```dockerfile
+FROM kisiodigital/proj-ci:7.2.1-artifacts as proj-artifacts
+
+FROM debian:stretch
+
+COPY --from=proj-artifacts /proj-artifacts /
+ARG PROJ_RUNTIME_DEPENDENCIES="clang-7 libtiff5 libcurl3-nss libsqlite3-0"
+RUN apt update \
+    && apt install --yes ${PROJ_RUNTIME_DEPENDENCIES} \
+    && apt autoremove --yes \
+    && rm -rf /var/lib/apt/lists/*
+```
 
 ### `kisiodigital/proj-ci:7.2.1`
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ based on a Debian stretch.
 
 In order to use it in a multistage Docker image, you can do the following setup (make sure that clang is >=3.9).
 
-```sh
+```dockerfile
 FROM kisiodigital/proj-ci:7.2.1-artifacts as proj-artifacts
 
 FROM debian:stretch
 
 COPY --from=proj-artifacts /proj-artifacts /
-ARG RUNTIME_DEPENDENCIES="pkg-config libtiff5 libcurl3-nss libsqlite3-0 clang" # or clang-3.9
+ARG RUNTIME_DEPENDENCIES="clang-7 pkg-config libtiff5 libcurl3-nss libsqlite3-0"
 RUN apt update \
     && apt install --yes ${RUNTIME_DEPENDENCIES} \
     && apt autoremove --yes \
@@ -29,9 +29,10 @@ RUN apt update \
 
 Do not forget to install the runtime dependencies on which the [proj] artifacts depend.
 
-> For running `proj`, the following Debian packages are needed:
-> - 'clang' provides 'llvm-config', 'libclang.so' and 'stddef.h' needed for compiling 'proj-sys' (clang >=3.9 needed by proj-sys)
-> - 'pkg-config' needed by 'proj-sys' to find the installed version
+> For developing with or running `proj`, the following Debian packages are needed:
+>
+> - 'pkg-config' needed for compiling 'proj-sys' rust crate to find the installed version
+> - 'clang-7' provides 'llvm-config', 'libclang.so' and 'stddef.h' needed for compiling 'proj-sys' (clang >=3.9 needed by proj-sys)
 > - 'libtiff5' provides 'libtiff.so', needed for linking when 'proj-sys' is used
 > - 'libcurl3-nss' provides 'libcurl-nss.so', needed for linking when 'proj-sys' is used
 > - 'libsqlite3-0' is used by proj to manage different projections definitions (EPSG)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ FROM kisiodigital/proj-ci:7.2.1-artifacts as proj-artifacts
 FROM debian:stretch
 
 COPY --from=proj-artifacts /proj-artifacts /
-ENV RUNTIME_DEPENDENCIES="clang libtiff5 libcurl3-nss libsqlite3-0"
+ARG RUNTIME_DEPENDENCIES="clang libclang1-3.9 pkg-config libtiff5 libcurl3-nss libsqlite3-0"
 RUN apt update \
     && apt install --yes ${RUNTIME_DEPENDENCIES} \
     && apt autoremove --yes \
@@ -30,7 +30,8 @@ RUN apt update \
 Do not forget to install the runtime dependencies on which the [proj] artifacts depend.
 
 > For running `proj`, the following Debian packages are needed:
-> - 'clang' provides 'llvm-config', 'libclang.so' and 'stddef.h' needed for compiling 'proj-sys'
+> - 'clang' provides 'llvm-config', 'libclang.so' and 'stddef.h' needed for compiling 'proj-sys' (version 3.9 needed by proj-sys)
+> - 'pkg-config' needed by 'proj-sys' to find the installed version
 > - 'libtiff5' provides 'libtiff.so', needed for linking when 'proj-sys' is used
 > - 'libcurl3-nss' provides 'libcurl-nss.so', needed for linking when 'proj-sys' is used
 > - 'libsqlite3-0' is used by proj to manage different projections definitions (EPSG)

--- a/proj/Dockerfile
+++ b/proj/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUNTIME_DEPENDENCIES="clang libtiff5 libcurl3-nss libsqlite3-0"
+ARG RUNTIME_DEPENDENCIES="clang-3.9 libtiff5 libcurl3-nss libsqlite3-0"
 
 FROM debian:stretch as builder
 ARG RUNTIME_DEPENDENCIES

--- a/proj/Dockerfile
+++ b/proj/Dockerfile
@@ -2,9 +2,9 @@ FROM debian:stretch as builder
 ARG PROJ_VERSION="7.2.1"
 
 # For building `libproj' and the Rust's crate `proj-sys`, the following Debian packages are needed:
-ENV BUILD_DEPENDENCIES="libcurl4-nss-dev libsqlite3-dev libtiff5-dev cmake pkg-config sqlite3 wget clang"
+ENV PROJ_BUILD_DEPENDENCIES="libcurl4-nss-dev libsqlite3-dev libtiff5-dev cmake pkg-config sqlite3 wget clang"
 RUN apt update \
-    && apt install --yes ${BUILD_DEPENDENCIES} \
+    && apt install --yes ${PROJ_BUILD_DEPENDENCIES} \
     && wget https://github.com/OSGeo/PROJ/releases/download/${PROJ_VERSION}/proj-${PROJ_VERSION}.tar.gz \
     && tar -xzvf proj-${PROJ_VERSION}.tar.gz \
     && mv proj-${PROJ_VERSION} /tmp/proj-src \
@@ -13,14 +13,14 @@ RUN apt update \
     && make -j$(nproc) \
     && make DESTDIR=/proj-artifacts install \
     && rm -fr /tmp/proj-src \
-    && apt purge --yes ${BUILD_DEPENDENCIES} \
+    && apt purge --yes ${PROJ_BUILD_DEPENDENCIES} \
     && apt autoremove --yes \
     && rm -rf /var/lib/apt/lists/*
 
 FROM debian:stretch
-ARG RUNTIME_DEPENDENCIES="clang-7 libtiff5 libcurl3-nss libsqlite3-0"
+ARG PROJ_RUNTIME_DEPENDENCIES="clang-7 libtiff5 libcurl3-nss libsqlite3-0"
 COPY --from=builder /proj-artifacts /
 RUN apt update \
-    && apt install --yes ${RUNTIME_DEPENDENCIES} \
+    && apt install --yes ${PROJ_RUNTIME_DEPENDENCIES} \
     && apt autoremove --yes \
     && rm -rf /var/lib/apt/lists/*

--- a/proj/Dockerfile
+++ b/proj/Dockerfile
@@ -1,13 +1,10 @@
-ARG RUNTIME_DEPENDENCIES="clang-3.9 libtiff5 libcurl3-nss libsqlite3-0"
-
 FROM debian:stretch as builder
-ARG RUNTIME_DEPENDENCIES
 ARG PROJ_VERSION="7.2.1"
 
 # For building `libproj' and the Rust's crate `proj-sys`, the following Debian packages are needed:
-ENV BUILD_DEPENDENCIES="libcurl4-nss-dev libsqlite3-dev libtiff5-dev cmake pkg-config sqlite3 wget"
+ENV BUILD_DEPENDENCIES="libcurl4-nss-dev libsqlite3-dev libtiff5-dev cmake pkg-config sqlite3 wget clang"
 RUN apt update \
-    && apt install --yes ${BUILD_DEPENDENCIES} ${RUNTIME_DEPENDENCIES} \
+    && apt install --yes ${BUILD_DEPENDENCIES} \
     && wget https://github.com/OSGeo/PROJ/releases/download/${PROJ_VERSION}/proj-${PROJ_VERSION}.tar.gz \
     && tar -xzvf proj-${PROJ_VERSION}.tar.gz \
     && mv proj-${PROJ_VERSION} /tmp/proj-src \
@@ -21,7 +18,7 @@ RUN apt update \
     && rm -rf /var/lib/apt/lists/*
 
 FROM debian:stretch
-ARG RUNTIME_DEPENDENCIES
+ARG RUNTIME_DEPENDENCIES="clang-7 libtiff5 libcurl3-nss libsqlite3-0"
 COPY --from=builder /proj-artifacts /
 RUN apt update \
     && apt install --yes ${RUNTIME_DEPENDENCIES} \

--- a/rust/proj/Dockerfile
+++ b/rust/proj/Dockerfile
@@ -3,7 +3,7 @@ ARG PROJ_VERSION=7.2.1
 FROM kisiodigital/proj-ci:${PROJ_VERSION}-artifacts as proj-artifacts
 FROM kisiodigital/rust-ci:${TAG}
 
-ARG RUNTIME_DEPENDENCIES="clang libclang1-3.9 pkg-config libtiff5 libcurl3-nss libsqlite3-0"
+ARG RUNTIME_DEPENDENCIES="clang-3.9 pkg-config libtiff5 libcurl3-nss libsqlite3-0"
 COPY --from=proj-artifacts /proj-artifacts /
 RUN apt update \
     && apt install --yes curl ${RUNTIME_DEPENDENCIES} \

--- a/rust/proj/Dockerfile
+++ b/rust/proj/Dockerfile
@@ -3,9 +3,9 @@ ARG PROJ_VERSION=7.2.1
 FROM kisiodigital/proj-ci:${PROJ_VERSION}-artifacts as proj-artifacts
 FROM kisiodigital/rust-ci:${TAG}
 
-ARG RUNTIME_DEPENDENCIES="clang-7 pkg-config libtiff5 libcurl3-nss libsqlite3-0"
+ARG PROJ_RUST_DEV_DEPENDENCIES="clang-7 pkg-config libtiff5 libcurl3-nss libsqlite3-0"
 COPY --from=proj-artifacts /proj-artifacts /
 RUN apt update \
-    && apt install --yes curl ${RUNTIME_DEPENDENCIES} \
+    && apt install --yes curl ${PROJ_RUST_DEV_DEPENDENCIES} \
     && apt autoremove --yes \
     && rm -rf /var/lib/apt/lists/*

--- a/rust/proj/Dockerfile
+++ b/rust/proj/Dockerfile
@@ -3,7 +3,7 @@ ARG PROJ_VERSION=7.2.1
 FROM kisiodigital/proj-ci:${PROJ_VERSION}-artifacts as proj-artifacts
 FROM kisiodigital/rust-ci:${TAG}
 
-ARG RUNTIME_DEPENDENCIES="clang libtiff5 libcurl3-nss libsqlite3-0"
+ARG RUNTIME_DEPENDENCIES="clang libclang1-3.9 pkg-config libtiff5 libcurl3-nss libsqlite3-0"
 COPY --from=proj-artifacts /proj-artifacts /
 RUN apt update \
     && apt install --yes curl ${RUNTIME_DEPENDENCIES} \

--- a/rust/proj/Dockerfile
+++ b/rust/proj/Dockerfile
@@ -3,7 +3,7 @@ ARG PROJ_VERSION=7.2.1
 FROM kisiodigital/proj-ci:${PROJ_VERSION}-artifacts as proj-artifacts
 FROM kisiodigital/rust-ci:${TAG}
 
-ARG RUNTIME_DEPENDENCIES="clang-3.9 pkg-config libtiff5 libcurl3-nss libsqlite3-0"
+ARG RUNTIME_DEPENDENCIES="clang-7 pkg-config libtiff5 libcurl3-nss libsqlite3-0"
 COPY --from=proj-artifacts /proj-artifacts /
 RUN apt update \
     && apt install --yes curl ${RUNTIME_DEPENDENCIES} \


### PR DESCRIPTION
Needed by https://github.com/CanalTP/transit_model/pull/743

Stricter separation of libproj build and use (no runtime deps on build):
* For libproj (C) build, clang (system package and shortcuts) is required in `BUILD_DEPENDENCIES`, as a c++11 compiler must be available on system, and it's only provided in `clang` package (not through it's dependency `clang-3.8` or any other `clang-*` package available on stretch).

Then, once libproj is built and available on the system:
* For a build of `proj` rust crate (dev-use, in rust), proj-sys needs `pkg_config` and `clang`>=`3.9` (chose `clang-7` as it's the debian-stable's version) to be able to detect the proj lib and link it.
* For proj use once built in a rust binary (and probably other non-dev use), took inspiration from https://packages.debian.org/bullseye/libproj19 (proj 7.2.1 on debian testing)  and kept pretty much the same that was there, just upgraded `clang` to `clang-7`. \
This part is used for [transit_model docker](https://github.com/CanalTP/transit_model/blob/5564b5190e4c1ad2a79d956718c25241f60a5342/Dockerfile#L8) for example.